### PR TITLE
14 auto mass

### DIFF
--- a/src/gui/custom_components.py
+++ b/src/gui/custom_components.py
@@ -1,4 +1,5 @@
 from PyQt5.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget, QLayout, QSizePolicy
+from PyQt5.QtCore import Qt
 import os
 
 # To work with PyInstaller, we need to get the absolute path for css file.
@@ -9,7 +10,6 @@ stylesheet = """
 
     #field {
         font-size: 15px;
-        qproperty-alignment: AlignRight;
         padding: 5px;
     }
 
@@ -82,8 +82,14 @@ class CustomTitle(QLabel):
 
 
 class CustomFieldLabel(QLabel):
-    def __init__(self, text):
+    def __init__(self, text, alignment=None):
         super(QLabel, self).__init__()
         self.setText(text)
         self.setObjectName('field')
         self.setStyleSheet(stylesheet)
+        if alignment == 'left':
+            self.setAlignment(Qt.AlignLeft)
+        elif alignment == 'center':
+            self.setAlignment(Qt.AlignLeft)
+        else:
+            self.setAlignment(Qt.AlignRight)

--- a/src/gui/file_picker_screen.py
+++ b/src/gui/file_picker_screen.py
@@ -29,6 +29,8 @@ class FilePickerScreen(QWidget):
 
         self.nav_buttons = NavigationButtons(
             on_next=self.on_next, on_back=self.on_back)
+        self.nav_buttons.btn_next.setDisabled(
+            len(self.state.file_time_pairs) == 0)
 
         self.btn_add = ActionButton("Add File")
         self.btn_add.clicked.connect(self.add_new_pairing)
@@ -41,6 +43,7 @@ class FilePickerScreen(QWidget):
         self.setLayout(self.outerLayout)
 
     def add_new_pairing(self):
+        self.nav_buttons.btn_next.setDisabled(False)
         self.state.add_record(
             ["", 0])
         length = len(self.state.file_time_pairs)
@@ -48,9 +51,10 @@ class FilePickerScreen(QWidget):
             PairListItem(self.state.file_time_pairs[-1], lambda i=length: self.remove_pairing(i-1), lambda i=length: self.state.update_record(self.state.file_time_pairs[i-1], i-1)))
 
     def remove_pairing(self, index):
-        print(index)
         self.state.remove_record(index)
         self.redraw()
+        if(len(self.state.file_time_pairs) == 0):
+            self.nav_buttons.btn_next.setDisabled(True)
 
 
 class PairListItem(QHBoxLayout):

--- a/src/gui/lipid_details_screen.py
+++ b/src/gui/lipid_details_screen.py
@@ -1,5 +1,6 @@
-from PyQt5.QtWidgets import QWidget, QFormLayout, QLabel, QVBoxLayout, QHBoxLayout, QSpacerItem, QComboBox, QLabel, QLineEdit, QSpinBox, QDoubleSpinBox
+from PyQt5.QtWidgets import QWidget, QFormLayout, QLabel, QVBoxLayout, QHBoxLayout, QSpacerItem, QComboBox, QLabel, QLineEdit, QSpinBox, QDoubleSpinBox, QCheckBox
 from gui.nav_buttons import NavigationButtons
+from PyQt5.QtCore import Qt
 from gui.custom_components import CustomTitle, CustomFieldLabel
 from molmass import Formula, FormulaError
 
@@ -37,8 +38,8 @@ class LipidDetailsScreen(QWidget):
         self.retention_time_tolerance.valueChanged.connect(
             page_state.setRetentionTimeTolerance)
 
-        self.mass = QDoubleSpinBox(decimals=6)
-        self.mass.setRange(0, 100)
+        self.mass = QDoubleSpinBox(decimals=10)
+        self.mass.setRange(0, 10000)
         self.mass.setValue(
             page_state.mass)
         self.mass.valueChanged.connect(
@@ -68,7 +69,13 @@ class LipidDetailsScreen(QWidget):
 
         self.content_layout = QFormLayout()
         self.content_layout.addRow(CustomFieldLabel(
-            "Isotope Formula"), self.lipid_formula)
+            "Lipid Formula"), self.lipid_formula)
+
+        self.lipid_formula_label = CustomFieldLabel("", alignment='left')
+        hill_not_label = CustomFieldLabel("Hill Notation: ")
+        hill_not_label.setAlignment(Qt.AlignLeft)
+        self.content_layout.addRow(CustomFieldLabel(
+            "Hill Notation: "), self.lipid_formula_label)
 
         self.content_layout.addRow(CustomFieldLabel(
             "Adduct Type"), self.adduct_type)
@@ -84,9 +91,14 @@ class LipidDetailsScreen(QWidget):
             "tolerance(s)"))
         rt_container.addWidget(self.retention_time_tolerance)
 
+        self.override = QCheckBox("Override Mass")
+        self.override.setChecked(False)
+        self.override.stateChanged.connect(self.override_toggled)
+        self.mass.setDisabled(True)
         mass_container = QHBoxLayout()
         mass_container.addWidget(CustomFieldLabel("Mass(m/z)"))
         mass_container.addWidget(self.mass)
+        mass_container.addWidget(self.override)
         mass_container.addWidget(CustomFieldLabel("tolerance"))
         mass_container.addWidget(self.mass_tolerance_units)
         mass_container.addWidget(self.mass_tolerance)
@@ -96,18 +108,26 @@ class LipidDetailsScreen(QWidget):
         self.screen_layout.addLayout(self.content_layout)
         self.nav_buttons = NavigationButtons(on_next=on_next)
         self.screen_layout.addWidget(self.nav_buttons)
+        self.validate_lipid_formula(self.lipid_formula.text())
 
         self.setLayout(self.screen_layout)
 
     def validate_lipid_formula(self, text):
         f = Formula(text)
-        valid = True
-
         try:
             formula = f.formula
             self.page_state.setLipidFormula(text)
             self.lipid_formula.setStyleSheet("border: 1px solid green")
-
+            self.lipid_formula_label.setText(f.formula)
+            self.nav_buttons.btn_next.setDisabled(False)
+            self.mass.setValue(f.isotope.mass)
         except FormulaError:
-            valid = False
             self.lipid_formula.setStyleSheet("border: 1px solid red")
+            self.lipid_formula_label.setText("")
+            self.nav_buttons.btn_next.setDisabled(True)
+
+    def override_toggled(self):
+        if self.override.isChecked():
+            self.mass.setDisabled(False)
+        else:
+            self.mass.setDisabled(True)

--- a/src/gui/lipid_details_screen.py
+++ b/src/gui/lipid_details_screen.py
@@ -1,6 +1,8 @@
 from PyQt5.QtWidgets import QWidget, QFormLayout, QLabel, QVBoxLayout, QHBoxLayout, QSpacerItem, QComboBox, QLabel, QLineEdit, QSpinBox, QDoubleSpinBox
 from gui.nav_buttons import NavigationButtons
 from gui.custom_components import CustomTitle, CustomFieldLabel
+from molmass import Formula, FormulaError
+
 import sys
 
 
@@ -8,9 +10,10 @@ class LipidDetailsScreen(QWidget):
     def __init__(self, page_state=None, on_next=None, on_back=None):
         super(LipidDetailsScreen, self).__init__()
 
-        self.isotope_formula = QLineEdit()
-        self.isotope_formula.setText(page_state.isotope_formula)
-        self.isotope_formula.textChanged.connect(page_state.setIsotopeFormula)
+        self.page_state = page_state
+        self.lipid_formula = QLineEdit()
+        self.lipid_formula.setText(page_state.lipid_formula)
+        self.lipid_formula.textChanged.connect(self.validate_lipid_formula)
 
         self.adduct_type = QComboBox()
         self.adduct_type.addItems(page_state.adduct_list)
@@ -65,7 +68,7 @@ class LipidDetailsScreen(QWidget):
 
         self.content_layout = QFormLayout()
         self.content_layout.addRow(CustomFieldLabel(
-            "Isotope Formula"), self.isotope_formula)
+            "Isotope Formula"), self.lipid_formula)
 
         self.content_layout.addRow(CustomFieldLabel(
             "Adduct Type"), self.adduct_type)
@@ -95,3 +98,16 @@ class LipidDetailsScreen(QWidget):
         self.screen_layout.addWidget(self.nav_buttons)
 
         self.setLayout(self.screen_layout)
+
+    def validate_lipid_formula(self, text):
+        f = Formula(text)
+        valid = True
+
+        try:
+            formula = f.formula
+            self.page_state.setLipidFormula(text)
+            self.lipid_formula.setStyleSheet("border: 1px solid green")
+
+        except FormulaError:
+            valid = False
+            self.lipid_formula.setStyleSheet("border: 1px solid red")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5==5.15.1
 mass-spec-utils==0.0.10
+molmass==2020.6.10

--- a/src/state/lipid_details_screen_state.py
+++ b/src/state/lipid_details_screen_state.py
@@ -1,8 +1,11 @@
+from molmass import Formula
+
+
 class LipidDetailsScreenState:
     def __init__(self):
         self.lipid_formula = ""
 
-        self.adduct_list = ['Item1', 'Item2', 'Item3', 'Item4', 'Item5']
+        self.adduct_list = ['[M+H]+', '[M+H]+', '[M+H]+', '[M+H]+', '[M+H]+']
         self.adduct_index = 0
 
         self.isotope_depth = 0
@@ -28,7 +31,7 @@ class LipidDetailsScreenState:
         }
 
     def setLipidFormula(self, text):
-        self.lipid_formula = text
+        self.lipid_formula = Formula(text).formula
 
     def setAdductIndex(self, text):
         self.adduct_index = text

--- a/src/state/lipid_details_screen_state.py
+++ b/src/state/lipid_details_screen_state.py
@@ -1,6 +1,6 @@
 class LipidDetailsScreenState:
     def __init__(self):
-        self.isotope_formula = ""
+        self.lipid_formula = ""
 
         self.adduct_list = ['Item1', 'Item2', 'Item3', 'Item4', 'Item5']
         self.adduct_index = 0
@@ -18,7 +18,7 @@ class LipidDetailsScreenState:
 
     def get_data_summary(self):
         return {
-            "Lipid Formula": self.isotope_formula,
+            "Lipid Formula": self.lipid_formula,
             "Adduct": self.adduct_list[self.adduct_index],
             "Isotope Depth": self.isotope_depth,
             "Retention Time": str(self.retention_time) + "s",
@@ -27,8 +27,8 @@ class LipidDetailsScreenState:
             "Mass Tolerance": str(self.mass_tolerance) + self.mass_tolerance_units_list[self.mass_tolerance_units_index]
         }
 
-    def setIsotopeFormula(self, text):
-        self.isotope_formula = text
+    def setLipidFormula(self, text):
+        self.lipid_formula = text
 
     def setAdductIndex(self, text):
         self.adduct_index = text

--- a/src/tests/test_unit.py
+++ b/src/tests/test_unit.py
@@ -2,6 +2,7 @@ import unittest
 from state.file_picker_screen_state import FilePickerScreenState
 from state.lipid_details_screen_state import LipidDetailsScreenState
 from state.input_summary_screen_state import InputSummaryScreenState
+from molmass import Formula
 
 # Smoke test to verify test suite runs
 
@@ -44,7 +45,7 @@ class InputSummaryScreenStateTests(unittest.TestCase):
             get_lipid_info=cls.lipid_state.get_data_summary, get_file_info=cls.file_picker_state.get_data_summary)
 
     def test_lipid_info_is_correct(self):
-        self.lipid_state.setLipid("C4356H4")
+        self.lipid_state.setLipidFormula("C4356H4")
         self.lipid_state.setAdductIndex(0)
         self.lipid_state.setIsotopeDepth(5)
         self.lipid_state.setMass(100.000)
@@ -53,8 +54,8 @@ class InputSummaryScreenStateTests(unittest.TestCase):
         self.lipid_state.setRetentionTime(100.000)
         self.lipid_state.setRetentionTimeTolerance(20)
 
-        self.assertDictEqual({"Lipid Formula": "C4356H4", "Isotope Depth": 5,
-                              "Adduct": "Item1", "Mass": 100.0, "Mass Tolerance": "20ppm",
+        self.assertDictEqual({"Lipid Formula": Formula("C4356H4").formula, "Isotope Depth": 5,
+                              "Adduct": "[M+H]+", "Mass": 100.0, "Mass Tolerance": "20ppm",
                               "Retention Time": "100.0s",
                               "Retention Time Tolerance": "20s"}, self.state.get_lipid_info())
 

--- a/src/tests/test_unit.py
+++ b/src/tests/test_unit.py
@@ -44,7 +44,7 @@ class InputSummaryScreenStateTests(unittest.TestCase):
             get_lipid_info=cls.lipid_state.get_data_summary, get_file_info=cls.file_picker_state.get_data_summary)
 
     def test_lipid_info_is_correct(self):
-        self.lipid_state.setIsotopeFormula("C4356H4")
+        self.lipid_state.setLipid("C4356H4")
         self.lipid_state.setAdductIndex(0)
         self.lipid_state.setIsotopeDepth(5)
         self.lipid_state.setMass(100.000)

--- a/timelog.md
+++ b/timelog.md
@@ -124,4 +124,14 @@
 
 ## 27 Oct 2020
 
--_1 hour_ - Wrote unit tests and made visual improments to input summary screen.
+- _1 hour_ - Wrote unit tests and made visual improments to input summary screen.
+- _0.5 hour_ - Implementing validation of lipid formula + mass calculation - Have added a red/green border round lipid field depending on if the formula entered is valid.
+
+## 29 Oct 2020
+
+- _1 hour_ - Next button is now disabled unless a valid formula is entered.
+- _1 hour_ - Implemented monoisotopic mass calculation.
+
+## 30 Oct 2020
+
+- _1 hour_ - Added checkbox to manually override mass.


### PR DESCRIPTION
# Problem :question:
|*What is the problem being addressed by this PR?*|
| --- |
| It is currently too easy for users to manually change mass without realising that this is usually a bad idea. |

# Solution :bulb:
|*How does this PR solve the problem*|
| --- |
| Adds a checkbox that must be clicked before mass field is enabled. Also auto calculates mass. |

# Summary :memo:
|*Give a brief summary of the work*|
| --- |
| Added override checkbox |
| Now performs mass calculation on formula entry |
| Now requires valid chemical formula before proceeding to file picker screen page. |
| Validation ensures that a file has been added before we can go to summary screen. |

# Issue :warning:
|*Which issue does this PR close/progress?*|
| --- |
| **:heavy_check_mark:Closes #14 ** |

# Checklist :ballot_box_with_check:
**_Do not submit PR until all items can be checked_**

- [x] This PR includes appropriate unit tests 
- [x] This PR adds any new test files to ```/.github/python-tests.yml``` workflow. 
- [x] There are no outstanding TODOs related to this issue