### PR TITLE
35 save lipid state

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -148,6 +148,10 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+
+output/*
+saved_runs/*
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/src/gui/add_adduct_window.py
+++ b/src/gui/add_adduct_window.py
@@ -9,6 +9,8 @@ import os
 
 class AddAdductWindow(QWidget):
     def __init__(self, state):
+        super(AddAdductWindow,self).__init__()
+
         self.state = state
         self.adductFormula = ""
         self.adduct_mult = 0.0
@@ -16,7 +18,6 @@ class AddAdductWindow(QWidget):
         self.adduct_label = ""
         self.charge_mode = ""
 
-        super().__init__()
         self.setWindowModality(Qt.ApplicationModal)
 
         self.setWindowTitle('New Adduct')

--- a/src/gui/export_lipids_window.py
+++ b/src/gui/export_lipids_window.py
@@ -1,0 +1,39 @@
+from PyQt5.QtWidgets import QWidget, QFormLayout, QLabel, QPushButton, QLineEdit, QLabel
+from PyQt5.QtCore import Qt
+
+
+class ExportLipidsWindow(QWidget):
+    def __init__(self, save_fn):
+        super(ExportLipidsWindow, self).__init__()
+
+        self.filename = ""
+        self.save_fn = save_fn
+        layout = QFormLayout(parent=self)
+        self.setWindowModality(Qt.ApplicationModal)
+
+        self.setWindowTitle('Export Lipid Data')
+
+        txt_filename = QLineEdit()
+        txt_filename.textChanged.connect(self.setFilename)
+
+        exit_button = QPushButton("Close")
+        exit_button.clicked.connect(lambda: self.close())
+
+        self.save_button = QPushButton("Save")
+        self.save_button.setEnabled(False)
+        self.save_button.clicked.connect(self.save)
+
+        layout.addRow(QLabel("Filename"), txt_filename)
+        layout.addRow(exit_button, self.save_button)
+
+    def save(self):
+        self.save_fn(self.filename)
+        self.close()
+
+    def setFilename(self, text):
+        self.filename = text
+
+        if(text == ""):
+            self.save_button.setEnabled(False)
+        else:
+            self.save_button.setEnabled(True)

--- a/src/gui/gui_controller.py
+++ b/src/gui/gui_controller.py
@@ -5,6 +5,8 @@ from gui.file_picker_screen import FilePickerScreen
 from gui.input_summary_screen import InputSummaryScreen
 from gui.progress_screen import ProgressScreen
 from gui.add_adduct_window import AddAdductWindow
+from gui.export_lipids_window import ExportLipidsWindow
+from gui.import_lipids_window import ImportLipidsWindow
 
 
 class MainApp(QMainWindow):
@@ -19,13 +21,27 @@ class MainApp(QMainWindow):
         fileMenu = mainMenu.addMenu('&File')
 
         add_adduct_action = QAction('&Add New Adduct', self)
-        self.w = AddAdductWindow(self.state.screen1)
-        add_adduct_action.triggered.connect(lambda: self.w.show())
+        adduct_window = AddAdductWindow(self.state.screen1)
+        add_adduct_action.triggered.connect(lambda: adduct_window.show())
+
+        export_lipid_action = QAction("&Export Lipids", self)
+        export_lipid_window = ExportLipidsWindow(
+            self.state.screen1.save_lipids)
+        export_lipid_action.triggered.connect(
+            lambda: export_lipid_window.show())
+
+        import_lipid_action = QAction("&Import Lipids", self)
+        import_lipid_window = ImportLipidsWindow(
+            self.import_lipids)
+        import_lipid_action.triggered.connect(
+            lambda: import_lipid_window.show())
 
         quit_action = QAction('&Quit', self)
         quit_action.triggered.connect(lambda: sys.exit())
 
         fileMenu.addAction(add_adduct_action)
+        fileMenu.addAction(export_lipid_action)
+        fileMenu.addAction(import_lipid_action)
         fileMenu.addAction(quit_action)
 
     def init_ui(self):
@@ -55,4 +71,8 @@ class MainApp(QMainWindow):
 
     def reset_state(self):
         self.state.wipe_state()
+        self.init_lipid_details_screen()
+
+    def import_lipids(self, filename):
+        self.state.screen1.restore_lipids(filename)
         self.init_lipid_details_screen()

--- a/src/gui/import_lipids_window.py
+++ b/src/gui/import_lipids_window.py
@@ -1,0 +1,38 @@
+from PyQt5.QtWidgets import QWidget, QLabel, QPushButton, QFileDialog, QFormLayout
+from PyQt5.QtCore import Qt
+import os
+
+
+class ImportLipidsWindow(QWidget):
+    def __init__(self, import_fn):
+        super(ImportLipidsWindow, self).__init__()
+        self.setWindowModality(Qt.ApplicationModal)
+        self.setWindowTitle('Import Lipid Data')
+        self.import_fn = import_fn
+
+        self.filepath = ""
+
+        layout = QFormLayout(parent=self)
+
+        self.btn_choose_file = QPushButton("Choose File...")
+        self.btn_choose_file.clicked.connect(self.choose_file)
+        self.lbl_filename = QLabel("")
+
+        btn_import = QPushButton("Import")
+        btn_import.clicked.connect(self.submit)
+
+        btn_close = QPushButton("Close")
+        btn_close.clicked.connect(lambda x: self.close())
+
+        layout.addRow(self.btn_choose_file, self.lbl_filename)
+        layout.addRow(btn_close, btn_import)
+
+    def choose_file(self):
+        self.filepath = os.path.abspath(QFileDialog.getOpenFileName(
+            QFileDialog(), "Choose File", os.getcwd() + os.sep + 'saved_runs', "JSON files(*.json)")[0]).split(os.sep)[-1]
+
+        self.lbl_filename.setText(self.filepath)
+
+    def submit(self):
+        self.import_fn(self.filepath)
+        self.close()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,3 +6,4 @@ scipy==1.5.4
 XlsxWriter==1.3.7
 numpy==1.19.3
 pymzml==2.4.7
+jsonpickle==1.4.2

--- a/src/state/lipid_details_screen_state.py
+++ b/src/state/lipid_details_screen_state.py
@@ -1,7 +1,7 @@
 from molmass import Formula, FormulaError
 from assets.pathFinder import get_resource_path
 from helper import mass2ion, parse_adduct_file
-
+import jsonpickle
 import os
 
 
@@ -43,6 +43,24 @@ class LipidDetailsScreenState:
             if not lipid.valid:
                 return False
         return True
+
+    def save_lipids(self, filename):
+        if not os.path.exists('saved_runs'):
+            os.makedirs('saved_runs')
+
+        with open("saved_runs/{}.json".format(filename), 'w') as f:
+            f.write(jsonpickle.encode(self.lipids))
+
+    def restore_lipids(self, filename):
+        if not os.path.exists('saved_runs'):
+            os.makedirs('saved_runs')
+            print(filename)
+
+        try:
+            with open("saved_runs/{}".format(filename), 'r') as f:
+                self.lipids = jsonpickle.decode(f.read())
+        except:
+            raise Exception
 
 
 class IndividualLipid:

--- a/src/tests/test_unit.py
+++ b/src/tests/test_unit.py
@@ -37,6 +37,20 @@ class LipidDetailsScreenStateTests(unittest.TestCase):
         self.assertDictEqual({'': {'formula': 'C4356H4', 'adduct': ['[M+H]+', 1.007276452, 1.0, ''], 'isotopeDepth': '5', 'retentionTime': '100.0s',
                                    'retentionTimeTolerance': '20s', 'mass': '100.0', 'massTolerance': '20', 'massToleranceUnits': 'ppm'}}, self.state.get_data_string_summary()[0])
 
+    def test_save_lipids_creates_file(self):
+        self.state.save_lipids("test")
+        assert(os.path.exists('saved_runs/test.json'))
+        os.remove('saved_runs/test.json')
+
+    def test_restore_lipids_restores_state(self):
+        self.state.save_lipids("test")
+        self.state.lipids = []
+        assert(len(self.state.lipids) == 0)
+
+        self.state.restore_lipids("test.json")
+        assert(len(self.state.lipids) == 1)
+        os.remove('saved_runs/test.json')
+
 
 class FilePickerScreenStateTests(unittest.TestCase):
     @classmethod

--- a/timelog.md
+++ b/timelog.md
@@ -258,3 +258,15 @@
 ## 3 Jan 2020
 
 - _1 hours_ - Triaged all dependencies to decide on a license and added license.
+
+## 4 Jan 2020
+
+- _5 hours_ - Fixed PyInstaller build. This was a massive issue and was very difficult to fix.
+
+## 5 Jan 2020
+
+- _2 hours_ - Added a release item to windows build. This should allow users to download and use for unit testing.
+
+## 6 Jan 2020
+
+- _5 hours_ - Implemented saving of lipid state.


### PR DESCRIPTION
# Problem :question:
|*What is the problem being addressed by this PR?*|
| --- |
| Users may have lots of lipids and so, should they wish to repeat a run, the need to enter all lipid detail manually. |

# Solution :bulb:
|*How does this PR solve the problem*|
| --- |
| This PR implements the saving of state to JSON, as well as the restoring of said state from JSON. |

# Summary :memo:
|*Give a brief summary of the work*|
| --- |
| Adds menubar items for import/export |
| Implements saving of data to 'saved_lipids' directory |
| Implements restoring of data from saved files. |
| Adds windows for managing exporting/importing |

# Issue :warning:
|*Which issue does this PR close/progress?*|
| --- |
| **:heavy_check_mark:Closes #34 and Closes #35** |

# Checklist :ballot_box_with_check:
**_Do not submit PR until all items can be checked_**

- [x] This PR includes appropriate unit tests 
- [x] This PR adds any new test files to ```/.github/python-tests.yml``` workflow. 
- [x] There are no outstanding TODOs related to this issue