### PR TITLE
Fixed mac and linux builds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,32 @@
 # Problem :question:
-|*What is the problem being addressed by this PR?*|
-| --- |
-| **YOUR ANSWER HERE** |
+
+| _What is the problem being addressed by this PR?_ |
+| ------------------------------------------------- |
+| **YOUR ANSWER HERE**                              |
 
 # Solution :bulb:
-|*How does this PR solve the problem*|
-| --- |
-|**YOUR ANSWER HERE**|
+
+| _How does this PR solve the problem_ |
+| ------------------------------------ |
+| **YOUR ANSWER HERE**                 |
 
 # Summary :memo:
-|*Give a brief summary of the work*|
-| --- |
-| **YOUR ANSWER HERE** |
+
+| _Give a brief summary of the work_ |
+| ---------------------------------- |
+| **YOUR ANSWER HERE**               |
 
 # Issue :warning:
-|*Which issue does this PR close/progress?*|
-| --- |
+
+| _Which issue does this PR close/progress?_                      |
+| --------------------------------------------------------------- |
 | **:heavy_check_mark:Closes #XXX** or **:construction:See #XXX** |
 
 # Checklist :ballot_box_with_check:
+
 **_Do not submit PR until all items can be checked_**
 
-- [ ] This PR includes appropriate unit tests 
-- [ ] This PR includes appropriate GUI tests 
-- [ ] This PR adds any new test files to ```/.github/python-tests.yml``` workflow. |
-- [ ] There are no outstanding TODOs related to this issue|
+- [ ] This PR includes appropriate unit tests
+- [ ] This PR includes appropriate GUI tests
+- [ ] This PR adds any new test files to `/.github/python-tests.yml` workflow.
+- [ ] There are no outstanding TODOs related to this issue

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -28,14 +28,19 @@ jobs:
           python-version: 3.7
       - name: Install dependencies
         run: |
+          ls ~
           python -m pip install --upgrade pip
+          pip install flake8 pytest
           pip install pyinstaller
+          pip install pymzml
           pip install -r src/requirements.txt
+
       - name: Build Executable
         run: |
           cd src/
-          pyinstaller -D --add-data "assets/styles.css:assets/" --add-data "assets/positive.csv:assets/" --add-data "assets/negative.csv:assets/" main.py
+          pyinstaller -D main.spec
+
       - uses: actions/upload-artifact@v2
         with:
-          name: main-executable
+          name: lipid_isotope_inference_software
           path: src/dist/main

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build Executable
         run: |
           cd src/
-          pyinstaller -D main.spec
+          pyinstaller -D --windowed main.spec
           ls -r
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           cd src/
           pyinstaller -D main.spec
+          ls -r
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -20,14 +20,17 @@ jobs:
           python-version: 3.7
       - name: Install dependencies
         run: |
+          ls ~
           python -m pip install --upgrade pip
+          pip install flake8 pytest
           pip install pyinstaller
+          pip install pymzml
           pip install -r src/requirements.txt
 
       - name: Build Executable
         run: |
           cd src/
-          pyinstaller -D --add-data "assets/styles.css:assets/" --add-data "assets/positive.csv:assets/" --add-data "assets/negative.csv:assets/" --windowed main.py
+          pyinstaller -D main.spec
 
       - uses: actions/upload-artifact@v2
         with:

--- a/timelog.md
+++ b/timelog.md
@@ -280,3 +280,11 @@
 
 - _2 hours_ - Finished implementing selection of multiple files.
 - _3 hour_ - Fixed the validation mess of lipid details screen and fixed the custom Adduct form.
+
+## 10 Jan 2020
+
+- _0.5 hours_ - Spent some time cleaning up repo and merge PRs
+
+## 11 Jan 2020
+
+- _1 hour_ -

--- a/timelog.md
+++ b/timelog.md
@@ -287,4 +287,4 @@
 
 ## 11 Jan 2020
 
-- _1 hour_ -
+- _1 hour_ - Fixing mac build and linuc builds - had issues with the way pyinstaller works with mac. This may need revisited.


### PR DESCRIPTION
# Problem :question:

| _What is the problem being addressed by this PR?_ |
| ------------------------------------------------- |
| Mac and Linux pyinstaller builds were not updated to use mian.spec.  |

# Solution :bulb:

| _How does this PR solve the problem_ |
| ------------------------------------ |
| Updates mac and Linux builds in line with Windows build |

# Summary :memo:

| _Give a brief summary of the work_ |
| ---------------------------------- |
| Mac build updated to use spec file. |
| Linux build updated to use spec file. |
| Updated merge template. |

# Issue :warning:

| _Which issue does this PR close/progress?_                      |
| --------------------------------------------------------------- |
| **:heavy_check_mark:Closes #40** |

# Checklist :ballot_box_with_check:

**_Do not submit PR until all items can be checked_**

- [x] This PR includes appropriate unit tests
- [x] This PR adds any new test files to `/.github/python-tests.yml` workflow.
- [x] There are no outstanding TODOs related to this issue
